### PR TITLE
Remove py pin since virtualenv works now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       before_install:
         - choco install python
         - python -m pip install --upgrade pip
-        - python -m pip install virtualenv
+        - python -m pip install -r requirements/ci.txt
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate        
       install:
@@ -61,7 +61,7 @@ jobs:
       python: 3.7
       # Perform the manual steps on osx to install python3 and activate venv
       before_install:
-        - python3 -m pip install virtualenv
+        - python -m pip install -r requirements/ci.txt
         - virtualenv $HOME/venv -p python3
         - source $HOME/venv/bin/activate
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       language: shell
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH      
       before_install:
-        - choco install python --version 3.7.3
+        - choco install python
         - python -m pip install --upgrade pip
         - python -m pip install virtualenv
         - virtualenv $HOME/venv

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,0 +1,1 @@
+virtualenv==16.6.2


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Windows Travis CI testing was pinned to py 3.7.3 because virtualenv was not compatible with py 3.7.4. Since fixed.

