### PR TITLE
Update default variable type to pass Terraform Validate for TF 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Find out more about Terraform workflows and using *scratchrelaxtv* [here](https:
 
 Here are two example workflows using *scratchrelaxtv*.
 
-**Original module development**: 
+**Original module development**:
 1. Write `main.tf` with whatever variables you need
 1. Run *scratchrelaxtv* to generate `variables.tf`
 1. Fill in descriptions, defaults, etc. in `variables.tf`
@@ -76,19 +76,19 @@ The generated `variables.tf`:
 ```hcl
 variable "create_bucket" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "bucket" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "region" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 ```
@@ -109,7 +109,7 @@ resource "aws_s3_bucket" "this" {
 ```hcl
 variable "bucket" {
   description = "The bucket where the stuff will be stored"
-  type        = "string"
+  type        = string
   default     = ""
 }
 ```
@@ -131,13 +131,13 @@ Now, the `variables.tf` looks like this:
 ```hcl
 variable "bucket" {
   description = "The bucket where the stuff will be stored"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "region" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 ```
@@ -150,19 +150,19 @@ Assume this `variables.tf`:
 ```hcl
 variable "id" {
   description = "The ID of the resource"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "bucket" {
   description = "The bucket where the stuff will be stored"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "region" {
   description = "The AWS region where the bucket lives"
-  type        = "string"
+  type        = string
   default     = ""
 }
 ```
@@ -227,7 +227,7 @@ TF_VAR_region=replace
 $ relaxtv -r
 ```
 
-*scratchrelaxtv* can also tidy up your directories by removing its own extra generated files. Presumably it will only remove files you no longer need but *be careful*. This chart shows examples of what would be deleted or not. 
+*scratchrelaxtv* can also tidy up your directories by removing its own extra generated files. Presumably it will only remove files you no longer need but *be careful*. This chart shows examples of what would be deleted or not.
 
 **NOTE**: *scratchrelaxtv* removes files in the current directory _and subdirectories_.
 

--- a/scratchrelaxtv/__init__.py
+++ b/scratchrelaxtv/__init__.py
@@ -161,7 +161,7 @@ class VarExtractor(BassExtractor):
                 file_handle.write(remove_prefix(tf_var, "var."))
                 file_handle.write('" {\n')
                 file_handle.write('  description = ""\n')
-                file_handle.write('  type        = "string"\n')
+                file_handle.write('  type        = string\n')
                 file_handle.write('  default     = ""\n')
                 file_handle.write('}\n\n')
 
@@ -296,7 +296,7 @@ class Checker(BassExtractor):
                 file_handle.write(tf_var)
                 file_handle.write('" {\n')
                 file_handle.write('  description = ""\n')
-                file_handle.write('  type        = "string"\n')
+                file_handle.write('  type        = string\n')
                 file_handle.write('  default     = ""\n')
                 file_handle.write('}\n')
 

--- a/tests/variables.tf
+++ b/tests/variables.tf
@@ -1,66 +1,66 @@
 variable "acl" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "bucket" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "create_2" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "create_keystore_bucket" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "now_a_var" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "org_ids" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "prefix" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "problem_var" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "region" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "tags" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "versioning" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 

--- a/tests/variables_missing.tf
+++ b/tests/variables_missing.tf
@@ -1,36 +1,36 @@
 variable "acl" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "bucket" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "problem_var" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "extra_var" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "region" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "versioning" {
   description = ""
-  type        = "string"
+  type        = string
   default     = ""
 }
 


### PR DESCRIPTION
Fixes #106 
Changes proposed in this pull request:

* Replace `type = "string"` with `type = string`

Output from Pytest:

```
================================================= test session starts ==================================================
platform darwin -- Python 3.7.2, pytest-4.1.0, py-1.7.0, pluggy-0.8.1
rootdir: /Users/jackhuman/dev/scratchrelaxtv, inifile: setup.cfg
collected 10 items                                                                                                     

tests/test_scratchrelaxtv.py ..........                                                                                  [100%]

============================================== 10 passed in 6.50 seconds ===============================================

```
